### PR TITLE
Fix go version in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: 1.21.4
+          go-version: 1.20
       - name: Run GoReleaser
         timeout-minutes: 60
         uses: goreleaser/goreleaser-action@44dd9927f499a126e26ae024981569ce889f15aa # v5.0.0


### PR DESCRIPTION
Fix the go version so that it matches what is in the go mod file