### PR TITLE
[IAC-98]Better support for only tagging specified list

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Datadog/cloud-resource-tagger/src/common/logger"
 	"github.com/Datadog/cloud-resource-tagger/src/common/reports"
 	"github.com/Datadog/cloud-resource-tagger/src/common/runner"
+	"github.com/Datadog/cloud-resource-tagger/src/common/tagging/gittag"
 	"github.com/Datadog/cloud-resource-tagger/src/common/tagging/utils"
 )
 
@@ -80,6 +81,13 @@ func tagCommand() *cli.Command {
 				Required:    false,
 				DefaultText: "path/to/terraform/root",
 				Value:       ".",
+			},
+			&cli.StringSliceFlag{
+				Name:        tagArg,
+				Aliases:     []string{"t"},
+				Usage:       "run only with the specified tags",
+				DefaultText: "dd_git_org,dd_git_repo,dd_git_file,dd_git_modified_commit,dd_git_resource_lines",
+				Value:       cli.NewStringSlice(gittag.GetMinimumDefaultGitTags()...),
 			},
 			&cli.StringFlag{
 				Name:        outputArg,

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Datadog/cloud-resource-tagger/src/common/logger"
 	"github.com/Datadog/cloud-resource-tagger/src/common/reports"
 	"github.com/Datadog/cloud-resource-tagger/src/common/runner"
-	"github.com/Datadog/cloud-resource-tagger/src/common/tagging/gittag"
 	"github.com/Datadog/cloud-resource-tagger/src/common/tagging/utils"
 )
 
@@ -87,7 +86,7 @@ func tagCommand() *cli.Command {
 				Aliases:     []string{"t"},
 				Usage:       "run only with the specified tags",
 				DefaultText: "dd_git_org,dd_git_repo,dd_git_file,dd_git_modified_commit,dd_git_resource_lines",
-				Value:       cli.NewStringSlice(gittag.GetMinimumDefaultGitTags()...),
+				// Value:       cli.NewStringSlice(gittag.GetMinimumDefaultGitTags()...),
 			},
 			&cli.StringFlag{
 				Name:        outputArg,

--- a/src/common/clioptions/cli_test.go
+++ b/src/common/clioptions/cli_test.go
@@ -38,6 +38,19 @@ func TestCliArgParsing(t *testing.T) {
 		options.Validate()
 	})
 
+	t.Run("Test tag argument parsing - valid specified tags", func(t *testing.T) {
+		options := TagOptions{
+			Directory:      "some/dir",
+			Tag:            []string{"tag1", "tag2"},
+			SkipTags:       nil,
+			Output:         "cli",
+			OutputJSONFile: "",
+			DryRun:         true,
+		}
+		// Expect the validation to pass without throwing errors
+		options.Validate()
+	})
+
 	t.Run("Test tag argument parsing - invalid output", func(t *testing.T) {
 		cmd := exec.Command(os.Args[0], "-test.run=TestOutputCrasher")
 		cmd.Env = append(cmd.Env, "UT_CRASH=RUN")

--- a/src/common/tagging/gittag/git_tag_group.go
+++ b/src/common/tagging/gittag/git_tag_group.go
@@ -248,3 +248,7 @@ func (t *TagGroup) cleanGCPTagValue(val tags.ITag) {
 
 	val.SetValue(updated)
 }
+
+func GetMinimumDefaultGitTags() []string {
+	return []string{"dd_git_org,dd_git_repo,dd_git_file,dd_git_modified_commit,dd_git_resource_lines"}
+}

--- a/src/common/version.go
+++ b/src/common/version.go
@@ -4,4 +4,4 @@
 // Copyright 2024-present Datadog, Inc.
 package common
 
-const Version = "0.0.9"
+const Version = "0.0.10"


### PR DESCRIPTION
We can now specify the explicit tags to apply by default for the CLI.
We will invoke the command with:
- dd_git_file
- dd_git_modified_commit
- dd_git_org
- dd_git_repo
- dd_git_resource_lines

Note- this still generates the full list when the CLI is run directly. We will add this specific tags argument at the github actions layer to allow for usecases with more tags under the hood or a more custom specification per client if needed.